### PR TITLE
Show detail on map when hover

### DIFF
--- a/docs/covid.js
+++ b/docs/covid.js
@@ -54,7 +54,8 @@ data.prefs.forEach(pref => {
         code: pref.code,
         jp: pref.pref,
         color: "rgba(" + Math.floor(255 * rate) + "," + Math.floor(255 * (1-rate)) + ",0,.8)",
-        prefectures: [pref.code]
+        prefectures: [pref.code],
+        pref: pref
     });
 
     var motal = pref.motarity.slice(-1)[0];
@@ -78,10 +79,32 @@ var mot = motarity.slice(-1)[0];
 charts.push(chart);
 firstrow.prepend(div);
 
+var onHover = function(data){
+    var dates = data.area.pref.dates.slice(-4);
+    var patients = data.area.pref.patients.slice(-4);
+    
+    var text = `
+${data.name}
+${dates[1]}: ${patients[1] - patients[0]}人
+${dates[2]}: ${patients[2] - patients[1]}人
+${dates[3]}: ${patients[3] - patients[2]}人
+`.trim();
+
+    var map = $("#map");
+    var message = $("#map-message");
+    
+    message.show()
+        .empty()
+        .append($("<pre>").text(text))
+        .css("left", map.position().left + map.width() - message.width() - 5)
+        .css("top", map.position().top + map.height() - message.height() - 8);
+}
+
 $("#map").japanMap({
     areas: areas,
     movesIslands: true,
-    height: 300
+    height: 300,
+    onHover: onHover
 });
 
 wholeJapan.sort((a, b) => b.patient - a.patient);

--- a/docs/index.html
+++ b/docs/index.html
@@ -24,6 +24,7 @@
         <div class="map-chart">
             <h2>感染拡大状況</h2>
         <div id="map"></div>
+        <div id="map-message"></div>
         <div class="map-description">
         2日での伸び率を基に色付け(赤: 感染拡大中, 緑: 感染収れん)
         </div>

--- a/docs/style.css
+++ b/docs/style.css
@@ -31,6 +31,16 @@ h2 {
     border-radius: 4px;
     padding: 10px;
 }
+#map-message {
+    display: none;
+    position: absolute;
+}
+#map-message pre{
+    margin: 0px;
+    font-size: small;
+    color: #aae;
+    line-height: 1.2;
+}
 .map-description {
     font-size: small;
     color: #aae;


### PR DESCRIPTION
地図上で都道府県にマウスカーソルを当てた際に、詳細を表示するようにしました。
![Screenshot](https://user-images.githubusercontent.com/847226/80870461-8bd8e880-8ce1-11ea-9f5f-cc009b3f323a.png)

### Note:

追加した `#map-message` ですが、JS で無理やり位置を調整しています。
CSS で位置を調整しようとする（ `#map-message` を右下に表示するために、CSS で `#map` の親を `position: relative` にする）と地図の選択がうまくできなくなるためです。